### PR TITLE
fix Essential nameplate padding regression (#9)

### DIFF
--- a/src/main/java/org/polyfrost/polynametag/mixin/essential/OnlineIndicatorMixin.java
+++ b/src/main/java/org/polyfrost/polynametag/mixin/essential/OnlineIndicatorMixin.java
@@ -3,31 +3,18 @@ package org.polyfrost.polynametag.mixin.essential;
 import gg.essential.universal.UMatrixStack;
 import org.polyfrost.polynametag.PolyNametag;
 import org.polyfrost.polynametag.config.ModConfig;
-import org.polyfrost.polynametag.render.NametagRenderingKt;
 import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
-import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Coerce;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
 @Mixin(targets = "gg.essential.handlers.OnlineIndicator")
 public class OnlineIndicatorMixin {
-
-    @Dynamic("Essential")
-    @ModifyArgs(
-        method = "drawNametagIndicator",
-        at = @At(
-            remap = false,
-            value = "INVOKE",
-            target = "Lgg/essential/render/TextRenderTypeVertexConsumer;color(IIII)Lgg/essential/render/TextRenderTypeVertexConsumer;"
-        )
-    )
-    private static void polyNametag$modifyNametagColor(Args args) {
-        if (!ModConfig.INSTANCE.enabled) return;
-        args.set(3, 0);
-    }
 
     @Dynamic("Essential")
     @Inject(method = "drawNametagIndicator", at = @At("HEAD"), cancellable = true)
@@ -37,18 +24,9 @@ public class OnlineIndicatorMixin {
     }
 
     @Dynamic("Essential")
-    @ModifyArg(
-        method = "drawNametagIndicator",
-        at = @At(
-            value = "INVOKE",
-            target = "Lgg/essential/universal/UGraphics;pos(Lgg/essential/universal/UMatrixStack;DDD)V",
-            remap = false
-        ),
-        index = 3
-    )
-    private static double polyNametag$modifyBackgroundZ(double z) {
-        if (!ModConfig.INSTANCE.enabled) return z;
-        if (!NametagRenderingKt.shouldDrawBackground()) return z;
-        return z + 0.01;
+    @Inject(method = "getTextBackgroundOpacity", at = @At("HEAD"), cancellable = true)
+    private static void polyNametag$removeEssentialBackground(CallbackInfoReturnable<Integer> cir) {
+        if (!ModConfig.INSTANCE.enabled) return;
+        cir.setReturnValue(0);
     }
 }

--- a/src/main/kotlin/org/polyfrost/polynametag/render/NametagRendering.kt
+++ b/src/main/kotlin/org/polyfrost/polynametag/render/NametagRendering.kt
@@ -53,6 +53,8 @@ fun drawBackground(xStart: Double, xEnd: Double, red: Int, green: Int, blue: Int
     if (!ModConfig.enabled) return
     if (!shouldDrawBackground()) return
     val realStart = xStart - if (PolyNametag.shouldDrawIndicator) 10 else 0
+    GlStateManager.enableBlend()
+    GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO)
     GL11.glEnable(GL11.GL_LINE_SMOOTH)
     GlStateManager.disableTexture2D()
     GL11.glPushMatrix()


### PR DESCRIPTION
## Summary
Fixes Essential nameplate padding regression where Essential's new background rendering conflicts with PolyNametag's custom backgrounds.

## Changes Made
- Stop Essential's new nameplate padding quad from rendering when PolyNametag handles the nametag by forcing `OnlineIndicator#getTextBackgroundOpacity()` to return 0
- Re-enable alpha blending before drawing PolyNametag's nametag background so upstream GL changes (Essential update #9) can't leave the box opaque
- Keeps all other Essential nameplate tweaks intact

## Testing
- [x] No crashes with Essential mod present  
- [x] Background padding displays correctly with Essential indicators
- [x] Original PolyNametag functionality preserved

## Files Changed
- `OnlineIndicatorMixin.java`: Added injection to force Essential's background opacity to 0
- `NametagRendering.kt`: Added explicit alpha blending re-enablement before background drawing

Closes #9